### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/georgebollas/8cc56fb7-9eb0-4341-b65c-976a30ee2091/91372f68-ec06-4ce7-ba03-d30a9857edcc/_apis/work/boardbadge/7eab9cc8-187d-4c27-8c91-9f59e3484e81)](https://dev.azure.com/georgebollas/8cc56fb7-9eb0-4341-b65c-976a30ee2091/_boards/board/t/91372f68-ec06-4ce7-ba03-d30a9857edcc/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes AB#1038. See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.